### PR TITLE
Update requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
 Django==1.5.4
 South==0.8.2
-distribute==0.6.19
+setuptools>=0.7
+#distribute==0.6.19
 django-floppyforms==1.0
 django-uni-form==0.8.0
 wsgiref==0.1.2
 django-bootstrap-toolkit==2.15.0
 M2Crypto==0.21.1
 vobject==0.8.1c
-Pillow-PIL
+#Pillow-PIL
 Pillow


### PR DESCRIPTION
Commenting out Pillow-PIL and distribute because they both consistently
cause errors while installing the application.

Not removing these lines completely because I am not 100% sure that no
system requires these libraries.
