### PR TITLE
Add google plus button to the sharebar at the bottom of blog posts

### DIFF
--- a/cms/templates/blogs/blog_post.html
+++ b/cms/templates/blogs/blog_post.html
@@ -25,10 +25,11 @@
     </div>
     <div class="shiv"></div>
     <div class="row">
-        <div class="span5 pull-right sharebar">
+        <div class="span6 pull-right sharebar">
             <span class='st_facebook_hcount' displayText='Facebook'></span>
             <span class='st_twitter_hcount' displayText='Tweet'></span>
             <span class='st_linkedin_hcount' displayText='LinkedIn'></span>
+            <span class='st_plusone_hcount' displayText='Google+'></span>
             <span class='st_email_hcount' displayText='Email'></span>
         </div>
     </div>


### PR DESCRIPTION
Continuing to use sharethis to generate the buttons.

Fixes: #70 
